### PR TITLE
Expand require handler to accept property

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,14 +122,15 @@ resolver.resolve(foo, function (err, data) {
 
 * `basedir` (*String*, optional) - The base path used for resolving relative path values. Defaults to `caller` dirname.
 
-Creates a handler which resolves and loads, and returns the specified module.
+Creates a handler which resolves and loads, and returns the property (if specified) or the module itself. The value should have the format `{module}(#property)?`.
 
 ```javascript
 var foo = {
     "path": "require:path",
     "minimist": "require:minimist",
     "mymodule": "require:./mymodule"
-    "json": "require:../config/myjson"
+    "json": "require:../config/myjson",
+    "myproperty": "require:./mymodule#myproperty"
 };
 
 var resolver = shortstop.create();
@@ -139,6 +140,7 @@ resolver.resolve(foo, function (err, data) {
     data.minimist; // `minimist` module as loaded from node_modules
     data.mymodule; // module as loaded from `./mymodule.js`
     data.json; // JS object as loaded from `../config/myjson.json`
+    data.myproperty; // value of myproperty got from `./mymodule.js`
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -125,16 +125,19 @@ function _env() {
 function _require(basedir) {
     var resolvePath = _path(basedir);
     return function requireHandler(value) {
-        var module = value;
+        var tuple, module, property;
 
+        tuple = value.split('#');
+        module = tuple[0];
+        property = tuple[1];
         // @see http://nodejs.org/api/modules.html#modules_file_modules
-        if (startsWith(value, '/') || startsWith(value, './') || startsWith(value, '../')) {
+        if (startsWith(module, '/') || startsWith(module, './') || startsWith(module, '../')) {
             // NOTE: Technically, paths with a leading '/' don't need to be resolved, but
             // leaving for consistency.
             module = resolvePath(module);
         }
 
-        return require(module);
+        return property ? require(module)[property] : require(module);
     };
 }
 

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -9,4 +9,6 @@ myModule.myFunction = function myFunction() {
     return 'myFunction';
 };
 
+myModule.myProperty = 'myProperty';
+
 module.exports = myModule;

--- a/test/index.js
+++ b/test/index.js
@@ -223,6 +223,15 @@ test('shortstop-common', function (t) {
         actual = handler(path.resolve(__dirname, '../package'));
         t.deepEqual(actual, expected);
 
+        // Module function
+        expected = 'myFunction';
+        actual = handler('./fixtures/index#myFunction')();
+        t.deepEqual(actual, expected);
+
+        // Module property
+        expected = require('./fixtures/index').myProperty;
+        actual = handler('./fixtures/index#myProperty');
+        t.deepEqual(actual, expected);
 
         t.end();
     });


### PR DESCRIPTION
Hi,

I  recently came across a case where I needed to give `console.log` as an option to an external module and since all related options for that external module were already defined in a config.json file, it made sense to also define `console.log` there.
I may be wrong, but it seems there is no way to do that for now except by defining a new function in a new module that returns a property or by setting the option in the application itself after the config has been loaded.
With this patch, it is possible to use this syntax in order to get a property from a module:

```json
"foo": {
    "myproperty": "require:./myModule#myProperty",
    "logging": "require:console#log"
}
```