### PR TITLE
Support `|!b` filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # shortstop-handlers
 
-[![Build Status](https://travis-ci.org/krakenjs/shortstop-handlers.svg?branch=master)](https://travis-ci.org/krakenjs/shortstop-handlers)  
+[![Build Status](https://travis-ci.org/krakenjs/shortstop-handlers.svg?branch=master)](https://travis-ci.org/krakenjs/shortstop-handlers)
 
 A common set of handlers for use with [shortstop](https://github.com/paypal/shortstop).
 
@@ -89,7 +89,7 @@ resolver.resolve(foo, function (err, data) {
 
 ### handlers.env()
 
-Creates a handler which will resolve the provided value as an environment variable, optionally casting the value using the provided filter. Supported filters are '|d' and '|b', which will cast to Number and Boolean types respectively.
+Creates a handler which will resolve the provided value as an environment variable, optionally casting the value using the provided filter. Supported filters are '|d', '|b', and '|!b' which will cast to Number and Boolean types respectively.
 
 ```javascript
 process.env.HOST = 'localhost';
@@ -102,6 +102,7 @@ var foo = {
     "baz": "env:PORT|d",
     "bam": "env:ENABLED|b",
     "bag": "env:FALSY|b"
+    "bat": "env:FALSY|!b"
 };
 
 var resolver = shortstop.create();
@@ -111,6 +112,7 @@ resolver.resolve(foo, function (err, data) {
     data.baz; // 8000
     data.bam; // true
     data.bag; // false
+    data.bat; // true
 });
 ```
 

--- a/index.js
+++ b/index.js
@@ -90,6 +90,9 @@ function _env() {
         },
         'b': function (value) {
             return value !== '' && value !== 'false' && value !== '0' && value !== undefined;
+        },
+        '!b': function (value) {
+            return value === '' || value === 'false' || value === '0' || value === undefined;
         }
     };
 

--- a/test/index.js
+++ b/test/index.js
@@ -172,6 +172,32 @@ test('shortstop-common', function (t) {
         actual = handler('SAMPLE|b');
         t.equal(actual, expected);
 
+        // Boolean (inverse)
+        process.env.SAMPLE = '8000';
+        expected = false;
+        actual = handler('SAMPLE|!b');
+        t.equal(actual, expected);
+
+        process.env.SAMPLE = 'true';
+        expected = false;
+        actual = handler('SAMPLE|!b');
+        t.equal(actual, expected);
+
+        process.env.SAMPLE = 'false';
+        expected = true;
+        actual = handler('SAMPLE|!b');
+        t.equal(actual, expected);
+
+        process.env.SAMPLE = '0';
+        expected = true;
+        actual = handler('SAMPLE|!b');
+        t.equal(actual, expected);
+
+        delete process.env.SAMPLE;
+        expected = true;
+        actual = handler('SAMPLE|!b');
+        t.equal(actual, expected);
+
         t.end();
     });
 


### PR DESCRIPTION
This is helpful when the option you want to adjust is configured opposite of the environment variable you want to use.
```
"doLongStartProcess": "env:DEV_MODE|!b"
```