### PR TITLE
support case when shortstop-handler is deployed as global dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,13 +13,16 @@ pids
 logs
 results
 coverage
+.nyc_output
 lib-cov
 html-report
 xunit.xml
 node_modules
 npm-debug.log
+package-lock.json
 
 .project
+.vscode
 .idea
 .settings
 .iml

--- a/index.js
+++ b/index.js
@@ -21,6 +21,17 @@ var glob = require('glob');
 var caller = require('caller');
 var thing = require('core-util-is');
 
+(function expandModulePaths() {
+    // If this module is deployed outside the app's node_modules, it wouldn't be
+    // able to resolve other modules deployed under app while evaluating this shortstops.
+    // Adding app's node_modules folder to the paths will help handle this case.
+    var paths = module.paths;
+    var appNodeModules = path.resolve(process.cwd(), 'node_modules');
+    if (paths.indexOf(appNodeModules) < 0) {
+        // Assuming Module._nodeModulePaths creates a new module.paths object for each module.
+        paths.push(appNodeModules);
+    }
+})();
 
 function startsWith(haystack, needle) {
     return haystack.indexOf(needle) === 0;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "tape test/*.js",
-    "cover": "istanbul cover tape -- test/*.js",
+    "cover": "nyc --reporter=lcov npm test && nyc report",
     "lint": "jshint -c .jshintrc index.js"
   },
   "repository": {
@@ -29,9 +29,9 @@
   ],
   "readmeFilename": "README.md",
   "devDependencies": {
-    "istanbul": "^0.4.4",
     "jshint": "^2.5.0",
-    "tape": "^4.6.0"
+    "nyc": "^15.1.0",
+    "tape": "^5.5.0"
   },
   "dependencies": {
     "caller": "^1.0.1",

--- a/test/fixtures/app/package.json
+++ b/test/fixtures/app/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "testapp1",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "testpkg1": "file:../pkg"
+  }
+}

--- a/test/fixtures/pkg/index.js
+++ b/test/fixtures/pkg/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function () {
+  return require('./package.json').name;
+};

--- a/test/fixtures/pkg/package.json
+++ b/test/fixtures/pkg/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "testpkg1",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
include process.cwd() in the module.paths to handle case when `shortstop-handler `is deployed outside the app's node_modules.

This is to support resolving `require:awesomemodule` in the below setup.

```
-                                               -  -  -  -      app-root
  |                                                                   |
   node_modules / shortstop_handlers.      |
                                                                      |
                                                                       node_modules / awesomemodule
```